### PR TITLE
Add example elections.md and results files for 2018, 2019 SC

### DIFF
--- a/elections/2018_SC/election.yaml
+++ b/elections/2018_SC/election.yaml
@@ -1,0 +1,18 @@
+name: 2018 Kubernetes Steering Committee Election
+organization: Kubernetes
+description:
+start_datetime: 2018-10-05 00:00:00
+end_datetime: 2018-10-27 00:00:00
+no_winners: 3
+condorcet_method:
+allow_no_opinion: True
+delete_after: True
+show_candidate_fields:
+  - Affiliation
+  - Github
+  - Twitter
+election_officers:
+  - jberkus
+  - jdumars
+  - markyjackson-taulia
+  - SergeyKanzhelev

--- a/elections/2018_SC/results.md
+++ b/elections/2018_SC/results.md
@@ -1,0 +1,4 @@
+Winners:
+- Aaron Crickenberger
+- Timothy St. Clair
+- Davanum Srinivas

--- a/elections/2019_SC/election.yaml
+++ b/elections/2019_SC/election.yaml
@@ -1,0 +1,18 @@
+name: 2019 Kubernetes Steering Committee Election
+organization: Kubernetes
+description:
+start_datetime: 2019-10-01 00:00:00
+end_datetime: 2019-10-21 00:00:00
+no_winners: 4
+condorcet_method:
+allow_no_opinion: True
+delete_after: True
+show_candidate_fields:
+  - Affiliation
+  - Github
+  - Twitter
+election_officers:
+  - jberkus
+  - jdumars
+  - markyjackson-taulia
+  - SergeyKanzhelev

--- a/elections/2019_SC/results.md
+++ b/elections/2019_SC/results.md
@@ -1,0 +1,26 @@
+## Results
+
+The final ranking, using the Condorcet-IRV method, is as follows:
+
+1. Paris Pittman
+2. Nikhita Raghunath
+3. Christoph Blecker
+4. Derek Carr
+5. Stephen Augustus
+6. Lachlan Evenson
+7. Brendan Burns
+8. Vallery Lancey
+9. Pengfei Ni
+10. Kris Nova
+11. Klaus Ma
+
+## Winners
+
+The winners of the open seats are as follows:
+
+Two year term:
+
+1. Paris Pittman
+2. Nikhita Raghunath
+3. Christoph Blecker
+4. Derek Carr


### PR DESCRIPTION
Example results.md files.  After some looking at files, I realized they need to be markdown, because elections admins may want to add narrative text or other information.

Some elections might also have different kinds of winners.  As such the two elections provide different examples of how the election results might be formatted.