### PR TITLE
Remove extra fields from voters.yaml.

### DIFF
--- a/elections/2020_DEC/election.yaml
+++ b/elections/2020_DEC/election.yaml
@@ -16,3 +16,7 @@ election_officers:
   - jdumars
   - markyjackson-taulia
   - SergeyKanzhelev
+eligibility: Eligibility is determined by Kubernetes contributions for the year.  See the main 2020
+  election page for more details on who is eligible and voting schedules.  If you are not listed
+  as an eligible voter and should be, request an exception.
+exception_form: https://www.surveymonkey.com/r/k8s-sc-election-2020

--- a/elections/2020_DEC/voters.yaml
+++ b/elections/2020_DEC/voters.yaml
@@ -1,13 +1,3 @@
-name: 2020 Steering Committee Election
-details: Eligibility is determined by Kubernetes contributions for the year.  See the main 2020
-  election page for more details on who is eligible and voting schedules.  If you are not listed
-  as an eligible voter and should be, request an exception.
-exception_form: https://www.surveymonkey.com/r/k8s-sc-election-2020
-history:
-- 2020-08-02: List of eligible voters derived by taking an export of Devstats contributions provided by Lukasz Gryglicki, combined with Org Members list taken from github.com/kubernetes/org via git clone
-- 2020-08-03: 68 voters who were excluded due to upper casing mismatches added to voters file
-- 2020-08-10: 2 voters who filed exception requests added
-- 2020-08-22: 84 additional voters added per Issue 5059: https://github.com/kubernetes/community/issues/5059
 eligible_voters:
 - 27149chen
 - 44past4

--- a/elections/2020_SC/election.yaml
+++ b/elections/2020_SC/election.yaml
@@ -1,6 +1,5 @@
 name: 2020 Kubernetes Steering Committee Election
 organization: Kubernetes
-description:
 start_datetime: 2020-10-01 00:00:00
 end_datetime: 2020-10-21 00:00:00
 no_winners: 3
@@ -16,3 +15,7 @@ election_officers:
   - jdumars
   - markyjackson-taulia
   - SergeyKanzhelev
+eligibility: Eligibility is determined by Kubernetes contributions for the year.  See the main 2020
+  election page for more details on who is eligible and voting schedules.  If you are not listed
+  as an eligible voter and should be, request an exception.
+exception_form: https://www.surveymonkey.com/r/k8s-sc-election-2020

--- a/elections/2020_SC/voters.yaml
+++ b/elections/2020_SC/voters.yaml
@@ -1,12 +1,3 @@
-details: Eligibility is determined by Kubernetes contributions for the year.  See the main 2020
-  election page for more details on who is eligible and voting schedules.  If you are not listed
-  as an eligible voter and should be, request an exception.
-exception_form: https://www.surveymonkey.com/r/k8s-sc-election-2020
-history:
-- 2020-08-02: List of eligible voters derived by taking an export of Devstats contributions provided by Lukasz Gryglicki, combined with Org Members list taken from github.com/kubernetes/org via git clone
-- 2020-08-03: 68 voters who were excluded due to upper casing mismatches added to voters file
-- 2020-08-10: 2 voters who filed exception requests added
-- 2020-08-22: 84 additional voters added per Issue 5059: https://github.com/kubernetes/community/issues/5059
 eligible_voters:
 - 27149chen
 - 44past4


### PR DESCRIPTION
Eligibility sentence and link to form are removed to elections.yaml file.
This makes voters.yaml only a list of voters and nothing else, which
is simpler.  The history was also removed; really we should be relying
on git history for that.

@SergeyKanzhelev please have a look.